### PR TITLE
Define missing color variables for service tables

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,6 +12,10 @@
   --glass: rgba(5,150,105,.07);
   --border: rgba(4,120,87,.13);
   --shadow: 0 14px 36px rgba(5,150,105,.13);
+  --pur: #7b2cbf;
+  --pur2: #9d4edd;
+  --org: #ff7a00;
+  --org2: #ffb35c;
 }
 body {
   font-family: 'Noto Sans Thai','IBM Plex Sans Thai',system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;


### PR DESCRIPTION
## Summary
- add purple and orange color variables to root palette
- ensure service table headers and related styles use defined variables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899699026608323bbe12e768d903c4a